### PR TITLE
refactor: exported color variables for color story

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { Button, ButtonVariant } from './Button';
 
 export default {
-  title: 'Button',
+  title: 'Components/Button',
   component: Button,
 } as ComponentMeta<typeof Button>;
 

--- a/src/styles/scss/colors.scss
+++ b/src/styles/scss/colors.scss
@@ -24,14 +24,54 @@ $tile-text--hover: #e6e6e6;
 //Special tiles
 $letter-double: #76a67c;
 $letter-double--hover: #6a9570;
-$letter-tripple: #354f52;
-$letter-tripple--hover: #30474a;
+$letter-triple: #354f52;
+$letter-triple--hover: #30474a;
 $word-double: #e09f3e;
 $word-double--hover: #ca8f38;
-$word-tripple: #9e2a2b;
-$word-tripple--hover: #8e2627;
+$word-triple: #9e2a2b;
+$word-triple--hover: #8e2627;
 
 //Semantic
 $danger: #cc0000;
 $positive: #1fc600;
 $warning: #ffff66;
+
+:export {
+  //Backgrounds
+  backgroundMain: $background-main;
+  backgroundBoard: $background-board;
+
+  //Accent colors
+  accent: $accent;
+  accentHover: $accent--hover;
+
+  //Text
+  text: $text;
+  textLight: $text--light;
+  textHover: $text--hover;
+  title: $title;
+  titleHover: $title--hover;
+  subTitle: $sub-title;
+  subTitleLight: $sub-title--light;
+
+  //Tiles
+  tile: $tile;
+  tileHover: $tile--hover;
+  tileText: $tile-text;
+  tileTextHover: $tile-text--hover;
+
+  //Special tiles
+  letterDouble: $letter-double;
+  letterDoubleHover: $letter-double--hover;
+  letterTriple: $letter-triple;
+  letterTripleHover: $letter-triple--hover;
+  wordDouble: $word-double;
+  wordDoubleHover: $word-double--hover;
+  wordTriple: $word-triple;
+  wordTripleHover: $word-triple--hover;
+
+  //Semantic
+  danger: $danger;
+  positive: $positive;
+  warning: $warning;
+}

--- a/src/styles/scss/paddings.scss
+++ b/src/styles/scss/paddings.scss
@@ -3,3 +3,11 @@ $sm: 0.25rem;
 $md: 0.375rem;
 $lg: 0.5rem;
 $xl: 0.625rem;
+
+:export {
+  xs: $xs;
+  sm: $sm;
+  md: $md;
+  lg: $lg;
+  xl: $xl;
+}

--- a/src/styles/stories/Colors/Colors.stories.mdx
+++ b/src/styles/stories/Colors/Colors.stories.mdx
@@ -1,57 +1,65 @@
 import { Meta, ColorPalette, ColorItem } from '@storybook/addon-docs';
 import '../../scss/colors.scss';
 
-<Meta title="Colors" />
+import colors from './colors.module.scss';
+
+<Meta title="Styles/Colors" />
 
 <ColorPalette>
   <ColorItem
     title="Backgrounds"
-    colors={{ 'background-main': '#eee8ea', 'background-board': '#cab7bc' }}
+    colors={{
+      'background-main': colors['backgroundMain'],
+      'background-board': colors['backgroundBoard'],
+    }}
   />
   <ColorItem
     title="Accent colors"
-    colors={{ accent: '#591D2D', 'accent--hover': '#73263A' }}
+    colors={{
+      accent: colors['accent'],
+      'accent--hover': colors['accentHover'],
+    }}
   />
   <ColorItem
     title="Text"
     colors={{
-      text: '#4d4d4d',
-      'text--light': '#666666',
-      'text--hover': '#591D2D',
-      title: '#1a1a1a',
-      'title--hover': '#591D2D',
-      'sub-title': '#bda5ab',
-      'sub-title--light': '#cdbbc0',
+      text: colors['text'],
+      'text--light': colors['textLight'],
+      'text--hover': colors['textHover'],
+      title: colors['title'],
+      'title--hover': colors['titleHover'],
+      'sub-title': colors['subTitle'],
+      'sub-title--light': colors['subTitleLight'],
     }}
   />
   <ColorItem
     title="Tiles"
     colors={{
-      tile: '#875c68',
-      'tile--hover': '#7a4a57',
-      'tile-text': '#ffffff',
-      'tile-text--hover': '#e6e6e6',
+      tile: colors['tile'],
+      'tile--hover': colors['tileHover'],
+      'tile-text': colors['tileText'],
+      'tile-text--hover': colors['tileTextHover'],
     }}
   />
   <ColorItem
     title="Special tiles"
     colors={{
-      'letter-double': '#76A67C',
-      'letter-double--hover': '#6a9570',
-      'letter-tripple': '#354f52',
-      'letter-tripple--hover': '#30474a',
-      'word-double': '#e09f3e',
-      'word-double--hover': '#ca8f38',
-      'word-tripple': '#9e2a2b',
-      'word-tripple--hover': '#8e2627',
+      'letter-double': colors['letterDouble'],
+      'letter-double--hover': colors['letterDoubleHover'],
+      'letter-triple': colors['letterTriple'],
+      'letter-triple--hover': colors['letterTripleHover'],
+      'word-double': colors['wordDouble'],
+      'word-double--hover': colors['wordDoubleHover'],
+      'word-triple': colors['wordTriple'],
+      'word-triple--hover': colors['wordTripleHover'],
     }}
   />
   <ColorItem
     title="Semantic colors"
     colors={{
-      danger: '#b80000',
-      positive: '#1cb200',
-      warning: '#e6e65c',
+      danger: colors['danger'],
+      positive: colors['positive'],
+      warning: colors['warning'],
     }}
   />
 </ColorPalette>

--- a/src/styles/stories/Colors/colors.module.scss
+++ b/src/styles/stories/Colors/colors.module.scss
@@ -1,0 +1,1 @@
+@import '../../scss/colors.scss';

--- a/src/styles/stories/Paddings/PaddingExample.stories.tsx
+++ b/src/styles/stories/Paddings/PaddingExample.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { PaddingExample, PaddingSize } from './PaddingExample';
 
 export default {
-  title: 'Paddings',
+  title: 'Styles/Paddings',
   component: PaddingExample,
   argTypes: { size: { control: 'select' } },
 } as ComponentMeta<typeof PaddingExample>;
@@ -13,7 +13,7 @@ const Template: ComponentStory<typeof PaddingExample> = (args) => (
 
 export const ExtraSmall = Template.bind({});
 ExtraSmall.args = {
-  size: PaddingSize.EXTRASMALL,
+  size: PaddingSize.EXTRA_SMALL,
 };
 
 export const Small = Template.bind({});
@@ -33,5 +33,5 @@ Large.args = {
 
 export const ExtraLarge = Template.bind({});
 ExtraLarge.args = {
-  size: PaddingSize.EXTRALARGE,
+  size: PaddingSize.EXTRA_LARGE,
 };

--- a/src/styles/stories/Paddings/PaddingExample.tsx
+++ b/src/styles/stories/Paddings/PaddingExample.tsx
@@ -4,15 +4,14 @@ import { FC } from 'react';
 import './PaddingExample.scss';
 
 export enum PaddingSize {
-  EXTRASMALL = 'xs',
+  EXTRA_SMALL = 'xs',
   SMALL = 'sm',
   MEDIUM = 'md',
   LARGE = 'lg',
-  EXTRALARGE = 'xl',
+  EXTRA_LARGE = 'xl',
 }
 
-export interface PaddingExampleProps
-  extends React.HTMLAttributes<HTMLDivElement> {
+export interface PaddingExampleProps {
   size: PaddingSize;
 }
 
@@ -33,9 +32,7 @@ const getSizeValue = (size: PaddingSize) => {
   }
 };
 
-export const PaddingExample: FC<PaddingExampleProps> = ({
-  size,
-}) => (
+export const PaddingExample: FC<PaddingExampleProps> = ({ size }) => (
   <div className={classNames('padding', `padding-${size}`)}>
     <div className="padding-text">{`Padding size :${getSizeValue(size)}`}</div>
   </div>


### PR DESCRIPTION
- Exported color and padding variables from the style files
- Refactored the colors story to use the exported variables
- Restructured stories in to `styles` and `components`
- Removed unnecessary property `extends` from Paddings example
- Fixed spelling mistakes
- Fixed `CONSTANT_CASE` variable naming mistakes