### PR TITLE
fix: made name prop optional for number and text inputs

### DIFF
--- a/src/components/NumberInput/NumberInput.tsx
+++ b/src/components/NumberInput/NumberInput.tsx
@@ -9,7 +9,7 @@ const { prefix } = variables;
 export interface NumberInputProps
   extends Omit<React.HTMLProps<HTMLDivElement>, 'onChange'> {
   id: string;
-  name: string;
+  name?: string;
   label: string;
   value?: number;
   min?: number;

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -9,7 +9,7 @@ const { prefix } = variables;
 export interface TextInputProps
   extends Omit<React.HTMLProps<HTMLDivElement>, 'onChange'> {
   id: string;
-  name: string;
+  name?: string;
   label: string;
   value?: string;
   onChange: (newValue: string) => void;


### PR DESCRIPTION
There was an error on scrabble-away game setup form about this. 